### PR TITLE
Removed import parametersbase line from __init__.py

### DIFF
--- a/ogusa/__init__.py
+++ b/ogusa/__init__.py
@@ -18,7 +18,6 @@ from ogusa.output_plots import *
 from ogusa.parameter_plots import *
 from ogusa.parameter_tables import *
 from ogusa.parameters import *
-from ogusa.parametersbase import *
 from ogusa.postprocess import *
 from ogusa.tax import *
 from ogusa.txfunc import *


### PR DESCRIPTION
This PR removes the `from ogusa.parametersbase import *` command from the `ogusa/__init__.py` file. This should solve the failing CI tests.