### PR TITLE
Updated setup.py and __init__.py version numbers

### DIFF
--- a/ogcore/__init__.py
+++ b/ogcore/__init__.py
@@ -19,4 +19,4 @@ from ogcore.tax import *
 from ogcore.txfunc import *
 from ogcore.utils import *
 
-__version__ = "0.9.2"
+__version__ = "0.10.0"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="ogcore",
-    version="0.9.2",
+    version="0.10.0",
     author="Jason DeBacker and Richard W. Evans",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="A general equilibribum overlapping generations model for fiscal policy analysis",


### PR DESCRIPTION
This PR updates the version number to `0.10.0` in both `setup.py` and `ogcore/__init__.py`.