### PR TITLE
Updates to Jupyter Book related files

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -26,14 +26,12 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install -e .
-          pip install jupyter-book>=0.11.3
-          pip install sphinxcontrib-bibtex>=2.0.0
           python -m ipykernel install --user --name=ogcore-dev
           cd docs
           jb build ./book
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.

--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        uses: actions/checkout@v4 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
         with:
           persist-credentials: false
 
@@ -23,8 +23,6 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install -e .
-          pip install jupyter-book>=0.11.3
-          pip install sphinxcontrib-bibtex>=2.0.0
           python -m ipykernel install --user --name=ogcore-dev
           cd docs
           jb build ./book

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 dependencies:
 - python>=3.7.7, <3.12
+- numpy
 - ipython
 - setuptools
 - scipy>=1.7.1
@@ -12,6 +13,13 @@ dependencies:
 - dask-core>=2.30.0
 - distributed>=2.30.1
 - paramtools>=0.15.0
+- sphinx
+- sphinx-argparse
+- sphinxcontrib-bibtex>=2.0.0
+- sphinx-math-dollar
+- pydata-sphinx-theme
+- jupyter-book>=0.11.3
+- jupyter
 - pytest>=6.0
 - pytest-xdist
 - pylint
@@ -22,3 +30,4 @@ dependencies:
 - pip
 - pip:
   - pygam
+  - linecheck

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setuptools.setup(
     include_packages=True,
     python_requires=">=3.7.7, <3.12",
     install_requires=[
+        "numpy",
         "scipy>=1.7.1",
         "pandas>=1.2.5",
         "matplotlib",


### PR DESCRIPTION
@jdebacker. This PR should fix the failing Jupyter Book `docs_check` and `docs_build` GH Actions. This PR:
- Adds Jupyter Book package requirements to the `environment.yml` file, but not to `setup.py`.
- Updated some of the Action files and removed some duplicated installs in `deploy_docs.yml` and `docs_check.yml`