### PR TITLE
Add jupyter-book and jupyter to setup.py

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
 - sphinxcontrib-bibtex>=2.0.0
 - sphinx-math-dollar
 - pydata-sphinx-theme
-- jupyter-book>=0.11.3
+- jupyter-book<2.0.0
 - jupyter
 - pytest>=6.0
 - pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ setuptools.setup(
         "requests",
         "pip",
         "pygam",
+        "jupyter-book>=0.11.3",
+        "jupyter"
     ],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
         "requests",
         "pip",
         "pygam",
-        "jupyter-book>=0.11.3",
+        "jupyter-book<2.0.0",
         "jupyter"
     ],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setuptools.setup(
         "pip",
         "pygam",
         "jupyter-book<2.0.0",
-        "jupyter"
+        "jupyter",
     ],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,6 @@ setuptools.setup(
         "requests",
         "pip",
         "pygam",
-        "jupyter-book<2.0.0",
-        "jupyter",
     ],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",


### PR DESCRIPTION
@jdebacker. I think this might fix the error we are getting in the GitHub action for building the docs. There is sometimes a difference between the conda environment (`ogcore-dev`) and the packages that get installed from PyPI.org (`pip install ogcore`, from `setup.py`). The goal of this PR is to add the `jupyter` and `jupyter-book` packages as components of the PyPI.org `ogcore` package.

Review and merge this and see if this fixes the GitHub Action. I can't really test this locally on my machine.